### PR TITLE
separate pipeline doc

### DIFF
--- a/models/README.md
+++ b/models/README.md
@@ -5,7 +5,8 @@ Power models are stored with the following file structure.
 ```yaml
 └── <version>
     ├── README.md
-    └── nx12
+    └── <machine_id>
+        ├── <pipeline_name>.zip # archived pipeline (optional)
         ├── preprocessed_data
         │   ├── *_data.csv # raw preprocess data (optional)
         │   └── preprocess_*.png # visualized preprocess data   
@@ -23,5 +24,5 @@ Power models are stored with the following file structure.
 
 Machine ID|CPU Architecture|CPU model (optional)|#sockets (optional)|OS|Kernel version
 ---|---|---|---|---|---
-nx12|x64|[Intel® Xeon® Processor E5-2667 v3](https://ark.intel.com/content/www/us/en/ark/products/83361/intel-xeon-processor-e52667-v3-20m-cache-3-20-ghz.html)|2|Ubuntu|5.15.0-78-generic
+nx12|x86_64|[Intel® Xeon® Processor E5-2667 v3](https://ark.intel.com/content/www/us/en/ark/products/83361/intel-xeon-processor-e52667-v3-20m-cache-3-20-ghz.html)|2|Ubuntu|5.15.0-78-generic
 

--- a/models/v0.6/.doc/std_v0.6.md
+++ b/models/v0.6/.doc/std_v0.6.md
@@ -1,0 +1,35 @@
+# Pipeline std_v0.6
+
+## Description
+
+This pipeline is introduced as an intial pipeline for the first release of kepler-model-server which is align with Kepler release v0.6.
+
+## Components
+
+- **Extractor:** DefaultExtractor
+- **Isolator:** MinIsolator
+- **Trainers:**
+    - SGDRegressorTrainer
+    - SVRRegressorTrainer
+    - KNeighborsRegressorTrainer
+    - LinearRegressionTrainer
+    - GradientBoostingRegressorTrainer
+    - Model PolynomialRegressionTrainer
+
+## Workload information
+
+### stressng
+- stress
+    - CPU (cpu) 
+    - branch to 1024 randomly selected locations and hence exercise (branch)  
+    - cyclic nanosecond sleeps (cyclic) 
+    - exercising CPU generic registers (regs)
+    - CPU level 1 cache with reads and writes (l1cache)
+    - CPU cache with random wide spread memory read and writes to thrash the CPU cache (cache)
+    - "Sustainable Memory Bandwidth in High Performance Computers" benchmarking tool by John D. McCalpin (stream)
+    - virtual memory (vm-rw) 16G
+    - mix of sequential, random and memory mapped read/write operations (iomix)
+    - pipe write operations (pipe)
+    - network performing SCTP send/receives (sctp)
+- n = 4, 8, 15*, 32 where *max CPU cores in baselineMachine is 15
+- Max CPU frequency = 2GHz, 2.8GHz, 3.6GHz

--- a/models/v0.6/README.md
+++ b/models/v0.6/README.md
@@ -1,53 +1,7 @@
-# Pre-release Build
-
-The pipeline in this folder is trained by Kepler model server towards v0.6.
-
-## Pipeline information
-
-- **Extractor:** DefaultExtractor
-- **Isolator:** MinIsolator
-- **Trainers:**
-    - SGDRegressorTrainer
-    - SVRRegressorTrainer
-    - KNeighborsRegressorTrainer
-    - LinearRegressionTrainer
-    - GradientBoostingRegressorTrainer
-    - Model PolynomialRegressionTrainer
-
-## Workload information
-
-- stressng
-- coremark
-    ```yaml
-        repetition: 5
-        iterationSpec:
-            iterations:
-            - name: thread
-            values:
-            - "4"
-            - "8"
-            - "16"
-            - "32"
-    ```
-- parsec
-    ```yaml
-        repetition: 1
-        interval: 10
-        iterationSpec:
-            iterations:
-            - name: input
-            values:
-            - "native"
-            - name: package
-            values:
-            - "bodytrack"
-            - "canneal"
-            - "raytrace"
-            - "ferret"
-    ```
+# v0.6 Build
 
 ## Trained pipelines
 
-Machine ID|raw data|trained pipeline|collect time|last update time
----|---|---|---|---
-nx12|&check;|&check;|2023-08-28 19:26:30|2023-09-01 07:32:51
+machine ID|trained pipeline|raw data|collect time|last update time|publisher|AbsPower (acpi)|AbsPower (rapl)|DynPower (acpi)|DynPower (rapl)
+---|---|---|---|---|---|---|---|---|---
+nx12|[std_v0.6](./.doc/std_v0.6.md)|&check;|2023-08-28 19:26:30|2023-09-01 07:32:51|[sunya-ch](https://github.com/sunya-ch)|[metadata list](./nx12/std_v0.6/acpi_AbsPower_model_metadata.csv)|[metadata list](./nx12/std_v0.6/rapl_AbsPower_model_metadata.csv)|[metadata list](./nx12/std_v0.6/acpi_DynPower_model_metadata.csv)|[metadata list](./nx12/std_v0.6/rapl_DynPower_model_metadata.csv)


### PR DESCRIPTION
This PR addresses TODO in https://github.com/sustainable-computing-io/kepler-model-db/issues/5. 

- separate pipeline description to another folder
- add pipeline column in models/README.md#trained-pipelines with link to pipeline description
- add publisher column in models/README.md#trained-pipelines with link to GitHub account page

Also, 
- fix some typo
- add link to metadata files

Signed-off-by: Sunyanan Choochotkaew <sunyanan.choochotkaew1@ibm.com>