### PR TITLE
add pr template options

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/issue_fix_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/issue_fix_template.md
@@ -1,0 +1,6 @@
+### What is the issue you are fixing?
+<!--
+If this has been previously discussed, include links to relevant issues/discussions
+-->
+
+### How does this PR resolve the issue?

--- a/.github/PULL_REQUEST_TEMPLATE/new_feature_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_feature_template.md
@@ -1,0 +1,6 @@
+### What feature are you adding?
+<!--
+If this has been previously discussed, include links to relevant issues/discussions
+-->
+
+### Describe your changes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+<!--
+Please go the the "Preview" tab and select the appropriate sub-template.
+
+If none match, you may clear the text below and create your PR here.
+-->
+What is the purpose of your PR?
+* [Upload new model](?expand=1&template=add_pipeline_template.md)
+* [Fix an issue](?expand=1&template=issue_fix_template.md)
+* [Add a new feature](?expand=1&template=new_feature_template.md)


### PR DESCRIPTION
As discussed in https://github.com/sustainable-computing-io/kepler-model-db/issues/5#issuecomment-1716819397, this PR adds a default PR template that links to specialized PR templates depending on the author's purpose of the PR.